### PR TITLE
Add basic website for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ python chatbot.py
 Type your question in Russian and the bot will respond with the closest answer or a list of recommended links.
 
 Type `exit` to quit the chat.
+
+## Website
+
+A minimal static site is available in the `docs` directory. To publish it on GitHub Pages:
+
+1. Push this repository to GitHub.
+2. In the repository **Settings**, enable GitHub Pages for the `docs/` folder.
+3. GitHub will provide a public URL for your site after a few minutes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NamazApp Support Chatbot</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; line-height: 1.6; }
+        code { background-color: #f2f2f2; padding: 2px 4px; }
+    </style>
+</head>
+<body>
+    <h1>NamazApp Support Chatbot</h1>
+    <p>This project provides a simple command line chatbot for answering questions from the NamazApp FAQ.</p>
+    <h2>Setup</h2>
+    <p>Install the required dependency:</p>
+    <pre><code>pip install scikit-learn</code></pre>
+    <p>Run the chatbot:</p>
+    <pre><code>python chatbot.py</code></pre>
+    <p>Type your question in Russian and the bot will reply with the closest answer or recommended links. Type <code>exit</code> to quit.</p>
+    <p>See the <a href="../README.md">README</a> for details.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `docs/index.html` for a minimal static site
- document how to publish the site via GitHub Pages

## Testing
- `python -m py_compile chatbot.py`

------
https://chatgpt.com/codex/tasks/task_e_6858570aef80832994db60782a99c23d