### PR TITLE
Fix web chat instructions and allow CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This repository provides a lightweight command line chatbot for the NamazApp. Th
 1. Install Python dependencies (requires Python 3.8+):
 
 ```bash
-pip install scikit-learn
+pip install scikit-learn flask
 ```
 
-2. Run the chatbot:
+2. Run the command line chatbot:
 
 ```bash
 python chatbot.py
@@ -19,3 +19,23 @@ python chatbot.py
 Type your question in Russian and the bot will respond with the closest answer or a list of recommended links.
 
 Type `exit` to quit the chat.
+
+## Web Chat
+
+A simple web interface is provided in `webapp/`. Make sure the Flask package is installed and then start the server. Visit `http://localhost:8000` in your browser (do not open the HTML file directly):
+
+```bash
+python webapp/app.py
+```
+
+The `docs` folder contains the same HTML page configured for GitHub Pages. Update the `BACKEND_URL` constant inside `docs/index.html` to point to your deployed server.
+
+## Deploy
+
+Use the `deploy.sh` script to push this project to GitHub and enable GitHub Pages for the `docs/` folder:
+
+```bash
+./deploy.sh myuser/myrepo
+```
+
+The script uses the GitHub CLI (`gh`) and will output the public Pages URL. You can then deploy `webapp/app.py` to any Python hosting service (Heroku, Render, etc.) and update `BACKEND_URL` accordingly.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Deploy repository to GitHub and enable GitHub Pages
+# Usage: ./deploy.sh <user/repo>
+set -e
+
+REPO="$1"
+if [ -z "$REPO" ]; then
+  echo "Usage: $0 <user/repo>" >&2
+  exit 1
+fi
+
+# Create repo if it does not exist and push
+if ! gh repo view "$REPO" >/dev/null 2>&1; then
+  gh repo create "$REPO" --public --source=. --remote=origin --push
+else
+  git push -u origin $(git rev-parse --abbrev-ref HEAD)
+fi
+
+# Enable GitHub Pages from docs folder
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+PAGES_JSON=$(printf '{"source":{"branch":"%s","path":"docs"}}' "$BRANCH")
+
+gh api --method=POST "/repos/$REPO/pages" --input - <<<"$PAGES_JSON" >/dev/null
+
+# Retrieve and display the Pages URL
+URL=$(gh api "/repos/$REPO/pages" --jq '.html_url')
+echo "GitHub Pages URL: $URL"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NamazApp Chatbot</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        #chat { max-width: 600px; margin: auto; }
+        .msg { margin: 0.5em 0; }
+        .user { font-weight: bold; }
+        .bot { color: #005a9c; }
+    </style>
+</head>
+<body>
+<div id="chat">
+    <h1>NamazApp Chatbot</h1>
+<p>This page talks to a Flask backend. Update <code>BACKEND_URL</code> in the script below so it points to your running server (for example <code>http://localhost:8000</code>). Serve this file via GitHub Pages or any static web server.</p>
+    <div id="messages"></div>
+    <input id="input" type="text" placeholder="Введите вопрос" style="width:80%">
+    <button onclick="send()">Отправить</button>
+</div>
+<script>
+const BACKEND_URL = 'http://localhost:8000'; // change to your server URL
+async function send() {
+    const input = document.getElementById('input');
+    const text = input.value.trim();
+    if (!text) return;
+    append('user', text);
+    input.value = '';
+    try {
+        const res = await fetch(BACKEND_URL + '/chat', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json'},
+            body: JSON.stringify({message:text})
+        });
+        const data = await res.json();
+        append('bot', data.response);
+    } catch (err) {
+        append('bot', 'Ошибка соединения. Убедитесь, что запущен сервер.');
+    }
+}
+function append(role, text) {
+    const div = document.getElementById('messages');
+    const p = document.createElement('p');
+    p.className = 'msg ' + role;
+    p.innerText = (role==='user'? 'Вы: ': 'Бот: ') + text;
+    div.appendChild(p);
+    div.scrollTop = div.scrollHeight;
+}
+</script>
+</body>
+</html>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,50 @@
+from flask import Flask, request, jsonify, render_template
+from chatbot import load_data, build_model, find_best_match
+
+app = Flask(__name__)
+
+
+@app.after_request
+def add_cors_headers(response):
+    """Allow browser-based clients to access the API."""
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    response.headers['Access-Control-Allow-Headers'] = 'Content-Type'
+    response.headers['Access-Control-Allow-Methods'] = 'GET,POST,OPTIONS'
+    return response
+
+data = load_data('data/faq_data.json')
+questions = [item['query'] for item in data]
+vectorizer, X = build_model(questions)
+
+
+def format_answer(answer):
+    if 'response' in answer:
+        return answer['response']
+    if 'recommended_items' in answer:
+        lines = []
+        for item in answer['recommended_items']:
+            lines.append(f"- {item['title']}: {item['url']}")
+        return "\n".join(lines)
+    return 'Извините, я не знаю ответа.'
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/chat', methods=['POST', 'OPTIONS'])
+def chat():
+    if request.method == 'OPTIONS':
+        # Preflight request
+        return '', 204
+    user_query = request.json.get('message', '')
+    if not user_query:
+        return jsonify({'response': 'Введите вопрос.'})
+    idx, _ = find_best_match(user_query, vectorizer, X, questions)
+    answer = data[idx]
+    return jsonify({'response': format_answer(answer)})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NamazApp Chatbot</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        #chat { max-width: 600px; margin: auto; }
+        .msg { margin: 0.5em 0; }
+        .user { font-weight: bold; }
+        .bot { color: #005a9c; }
+    </style>
+</head>
+<body>
+<div id="chat">
+    <h1>NamazApp Chatbot</h1>
+    <p>Open this page via <code>http://localhost:8000</code> after starting <code>webapp/app.py</code>.</p>
+    <div id="messages"></div>
+    <input id="input" type="text" placeholder="Введите вопрос" style="width:80%">
+    <button onclick="send()">Отправить</button>
+</div>
+<script>
+async function send() {
+    const input = document.getElementById('input');
+    const text = input.value.trim();
+    if (!text) return;
+    append('user', text);
+    input.value = '';
+    try {
+        const res = await fetch('/chat', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json'},
+            body: JSON.stringify({message:text})
+        });
+        const data = await res.json();
+        append('bot', data.response);
+    } catch (err) {
+        append('bot', 'Ошибка соединения. Убедитесь, что сервер работает.');
+    }
+}
+function append(role, text) {
+    const div = document.getElementById('messages');
+    const p = document.createElement('p');
+    p.className = 'msg ' + role;
+    p.innerText = (role==='user'? 'Вы: ': 'Бот: ') + text;
+    div.appendChild(p);
+    div.scrollTop = div.scrollHeight;
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- clarify how to launch web chat in README
- improve docs/index.html instructions and error handling
- provide error handling in Flask template
- add simple CORS headers and preflight support in Flask app

## Testing
- `python -m py_compile chatbot.py webapp/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6858570aef80832994db60782a99c23d